### PR TITLE
Fixed bug when repost grabs lines beginning with '-'

### DIFF
--- a/rp/repost.tf
+++ b/rp/repost.tf
@@ -180,8 +180,8 @@
     /unset _repost_file%;\
   /elseif ({-1} =/ ">REROUTE>*") \
     /eval /set _repost_prefix=%%{_repost_prefix_$[textencode({origin})]}%;\
-    /echo -w%{1} $[substr({-1},strlen(">REROUTE>"))]%;\
-    /send -w%{origin} $[strcat({_repost_prefix},substr({-1},strlen(">REROUTE>")))]%;\
+    /echo -w%{1} -- $[substr({-1},strlen(">REROUTE>"))]%;\
+    /send -w%{origin} -- $[strcat({_repost_prefix},substr({-1},strlen(">REROUTE>")))]%;\
     /unset _repost_prefix%;\
   /elseif ({-1} =/ "PREFIX *") \
     /let newprefix=$[substr({-1},strlen("PREFIX "))]%;\


### PR DESCRIPTION
There's a /echo and /send that can get confused when grabbing a log line that begins with '-' as it thinks it's an invalid options (or could possibly be a valid one.) This adds '--' to the two relevant lines to let them know there are no more options coming, before the line from the log.