### PR TITLE
end options before echo, for @mail with tiny/rhost

### DIFF
--- a/lib/vworld.tf
+++ b/lib/vworld.tf
@@ -58,7 +58,7 @@
     /return 0%;\
   /endif%;\
   /vw_ensure %{vw_world}%;\
-  /echo -w%{vw_world} %{vw_text}
+  /echo -w%{vw_world} -- %{vw_text}
 
 ;;; /vw_redirect [-k] [-m<matching>] <from>=<to>=<pattern>
 ; Redirects lines from world from matching pattern to virtual world to.


### PR DESCRIPTION
RhostMUSH, TinyMUSH, and TinyMUX use an @mail system that has you composing with lines that begin with with '-' and then '--' on it's own to send. It's also possible you might want to just begin a line with a '-' for another reason. This can can cause problems with /send and /echo so if they're taking arbitrary input, they should always get a '--' beforehand.